### PR TITLE
Fix CD scripts issues when managing tags

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -19,7 +19,7 @@ jobs:
       # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: echo "::set-env name=TAG_SLUG::$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')"
     - name: Remove npm tag for the deleted branch
-      run: npm dist-tag rm lit-solid $TAG_SLUG
+      run: npm dist-tag rm @solid/lit-term $TAG_SLUG
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - run: echo "Package tag \`$TAG_SLUG\` unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,10 @@ name: CD
 
 on: 
   push:
-    # This excludes tags from CD
     branches:
+    tags:
+      # This excludes tags from CD, as they should be published through a release
+      '!v*'
 
 env:
   CI: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.12.0'
-        registry-url: https://npm.pkg.github.com/
+        registry-url: 'https://registry.npmjs.org'
         scope: '@solid'
     - name: NPM install, test and publish
       run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `demo` directory provides an extremely basic working example that you can ru
 with the following commands:
 ```
 cd demo
-npm install --registry=https://npm.pkg.github.com/inrupt
+npm install
 node index.js
 ```
 


### PR DESCRIPTION
- A preview release was distributed for tags
- The teardown had a typo
- The release script and the README referenced the wrong registry
